### PR TITLE
Remove references to Passive Acoustics Metadata

### DIFF
--- a/_data/sidebars/sidebar_ioos.yml
+++ b/_data/sidebars/sidebar_ioos.yml
@@ -48,10 +48,6 @@ entries:
       url: /index.html#ioos-controlled-vocabularies
       output: web
 
-    - title: Passive Acoustics Metadata
-      url: /index.html#passive-acoustics-metadata
-      output: web
-
 
   - title: Software, Tools, and Projects
     output: web, pdf

--- a/_docs/index.md
+++ b/_docs/index.md
@@ -66,11 +66,7 @@ A [collection](http://ioos.github.io/animal-telemetry/) of documents describing 
 * [IOOS Animal Acoustic Telemetry (AAT) Data Project](http://ioos.github.io/animal-telemetry/aat_data_ioostech_wiki/).
 -->
 
-### **Passive Acoustics Metadata**
-The Metadata Convention for Passive Acoustic Recording defines metadata that supports the mission of the National Oceanic and Atmospheric Administration (NOAA) for acquisition, archiving, and dissemination of ocean passive acoustic data.
-* [Metadata Convention for Passive Acoustic Recording](https://ioos.github.io/passive-acoustics/)
-
-<br><br>
+<br>
 
 
 ## **Software, Tools, and Projects**


### PR DESCRIPTION
Removing Passive Acoustics Metadata link in sidebar and removing the blurb about passive acoustics metadata on the index page. This only eliminates the access points for that page. I was not able to find the markdown for that passive-acoustics page itself to deprecate it? Where is that in the repo files?